### PR TITLE
fix: CNX-7547 serialize get properties

### DIFF
--- a/src/plugins/BaseObjectSerializer.js
+++ b/src/plugins/BaseObjectSerializer.js
@@ -56,9 +56,6 @@ class BaseObjectSerializer {
       }
       return convertedList
     }
-    if (object instanceof Function) {
-      return await this.PreserializeEachObjectProperty(object.call(), closures)
-    }
     if (object instanceof Object) {
       return Object.fromEntries(await this.PreserializeEachObjectProperty(object, closures))
     }

--- a/src/plugins/BaseObjectSerializer.ts
+++ b/src/plugins/BaseObjectSerializer.ts
@@ -78,7 +78,15 @@ export class BaseObjectSerializer {
   ): Promise<Map<string, any>> {
     const converted = new Map<string, any>()
 
-    for (const key of Object.keys(o)) {
+    const getters = Object.entries(Object.getOwnPropertyDescriptors(Reflect.getPrototypeOf(o)))
+      .filter(([key, descriptor]) => typeof descriptor.get === 'function' && key !== '__proto__')
+      .map(([key]) => key)
+
+    const objectKeys = new Array<string>()
+    objectKeys.push(...Object.keys(o))
+    objectKeys.push(...getters)
+
+    for (const key of objectKeys) {
       const objKey = key as keyof object
       converted.set(
         BaseObjectSerializer.CleanKey(key),


### PR DESCRIPTION
Previously, properties on objects defined by getters were not being serialized.

```
export class DataTable {
    rowData = []
    get rowCount() {
        return this.rowData.length
    }
}
```
So in the above javascript class, the serializer would serialize the "rowData" property, but it would skip the "rowCount" property. Now both of these properties are serialized.