### PR TITLE
Fix: setting selectedHeaders variable for small commit objects

### DIFF
--- a/src/plugins/excel.js
+++ b/src/plugins/excel.js
@@ -599,13 +599,12 @@ export async function bake(
             selectedHeaders = filterArrayData(dialog.items, arrayData)
           } else if (previousHeaders) {
             selectedHeaders = filterArrayData(previousHeaders, arrayData)
-          } else {
-            selectedHeaders = arrayData
           }
         }
 
         if (signal.aborted) return
 
+        selectedHeaders ??= arrayData
         await addIdDataToObjectData(selectedHeaders)
         await bakeArray(selectedHeaders, rowStart, colStart, context)
       }


### PR DESCRIPTION
The "selectedHeaders" variable is not expected to be null or undefined. This variable should be set to a filtered version of the "arrayData" variable or set to the arrayData variable itself.

Currently, we are only setting the selectedHeaders to arrayData in certain conditions, but this should always be the case when selectedHeaders is not defined by some other method

To repro : try to receive this commit https://latest.speckle.dev/streams/85bc4f61c6/commits/be91ac6127. It will fail unless you apply this fix