### PR TITLE
Fix (Excel): CNX-9045 deserialize chunked data

### DIFF
--- a/src/components/ObjectChunkedListViewer.vue
+++ b/src/components/ObjectChunkedListViewer.vue
@@ -1,13 +1,11 @@
 <template>
-  <v-card :class="`my-1 pa-0 ${localExpand ? 'elevation-3' : 'elevation-0'} my-0`">
+  <v-card :class="`my-1 mb-0 pa-0 pb-2 ${localExpand ? 'elevation-3' : 'elevation-0'} my-0`">
     <v-card-title>
-      <v-chip color="" @click="toggleLoadExpand">
-        <v-icon class="mr-2" small>mdi-code-braces</v-icon>
+      <v-chip @click="toggleLoadExpand">
+        <v-icon small class="mr-2">mdi-code-array</v-icon>
         {{ keyName }}
-        <span class="caption ml-2">
-          {{ value.speckle_type ? value.speckle_type : 'Object' }}
-        </span>
-        <v-icon small class="ml-2">
+        <span class="caption ml-2">List (> {{ (value.length - 1) * 5000 }} elements)</span>
+        <v-icon class="ml-2" small>
           {{ localExpand ? 'mdi-minus' : 'mdi-plus' }}
         </v-icon>
       </v-chip>
@@ -15,6 +13,7 @@
         <v-card class="pt-3">
           <v-card-text class="caption">
             Receiving data from the Speckleverse...
+
             <v-progress-linear class="mt-2" indeterminate color="primary"></v-progress-linear>
             <v-btn class="mt-3" outlined x-small color="primary" @click="cancel">Cancel</v-btn>
           </v-card-text>
@@ -24,48 +23,52 @@
         <v-icon small>mdi-download</v-icon>
       </v-btn>
     </v-card-title>
-    <v-card-text v-if="localExpand" class="pr-0 pl-3">
+    <v-card-text v-if="localExpand" class="pb-0 pr-0 pl-3">
       <component
         :is="entry.type"
-        v-for="(entry, index) in objectEntries"
+        v-for="(entry, index) in rangeEntries"
         :key="index"
-        :key-name="entry.name"
+        :key-name="entry.key"
         :full-key-name="fullKeyName ? `${fullKeyName}.${entry.key}` : entry.key"
         :value="entry.value"
         :stream-id="streamId"
         :commit-id="commitId"
         :commit-msg="commitMsg"
+        :nearest-object-id="nearestObjectId"
+        :path-from-nearest-object="`${entry.pathFromNearestObject}`"
       ></component>
+    </v-card-text>
+    <v-card-text v-if="localExpand && currentLimit < value.length">
+      <v-btn small @click="loadMore">Show more</v-btn>
     </v-card-text>
     <filter-modal ref="modal" />
   </v-card>
 </template>
 <script>
 import { bake } from '../plugins/excel'
-
 let ac = new AbortController()
-
 export default {
-  name: 'ObjectSimpleViewer',
+  name: 'ObjectChunkedListViewer',
   components: {
     FilterModal: () => import('./FilterModal'),
-    ObjectListViewer: () => import('./ObjectListViewer'),
     ObjectSpeckleViewer: () => import('./ObjectSpeckleViewer'),
+    ObjectSimpleViewer: () => import('./ObjectSimpleViewer'),
     ObjectValueViewer: () => import('./ObjectValueViewer')
   },
   props: {
     value: {
-      type: Object
-    },
-    streamId: {
-      type: String,
-      default: null
+      type: Array,
+      default: () => []
     },
     keyName: {
       type: String,
       default: null
     },
     fullKeyName: {
+      type: String,
+      default: null
+    },
+    streamId: {
       type: String,
       default: null
     },
@@ -89,74 +92,75 @@ export default {
   data() {
     return {
       localExpand: false,
+      itemsPerLoad: 3,
+      currentLimit: 3,
       progress: false
     }
   },
   computed: {
-    objectEntries() {
-      if (!this.value) return []
-      let entries = Object.entries(this.value)
+    rangeEntries() {
       let arr = []
-      for (let [key, val] of entries) {
-        let name = key
-        if (key.startsWith('__')) continue
-        if (key[0] === '@') name = key.substring(1)
-        if (key === 'totalChildrenCount') name = 'total children count'
-        if (key === 'speckle_type') name = 'speckle type'
-
+      let index = 0
+      const delimiter = ':::'
+      for (let val of this.range) {
+        index++
         if (Array.isArray(val)) {
           arr.push({
-            key,
-            name,
+            key: `${index}`,
             value: val,
-            type: 'ObjectListViewer',
-            description: `List (${val.length} elements haha)`
+            type: 'ObjectChunkedListViewer',
+            pathFromNearestObject: this.pathFromNearestObject
+              ? this.pathFromNearestObject + (index - 1) + delimiter
+              : index - 1 + delimiter
           })
-          // TODO -> list value template displayer
         } else if (typeof val === 'object' && val !== null) {
           if (val.speckle_type && val.speckle_type === 'reference') {
             arr.push({
-              key,
-              name,
+              key: `${index}`,
               value: val,
               type: 'ObjectSpeckleViewer'
             })
           } else {
             arr.push({
-              key,
-              name,
+              key: `${index}`,
               value: val,
               type: 'ObjectSimpleViewer'
             })
           }
         } else {
           arr.push({
-            key,
-            name,
+            key: `${index}`,
             value: val,
             type: 'ObjectValueViewer'
           })
         }
       }
+
       arr.sort((a, b) => {
         if (a.type === b.type) return 0
         if (a.type === 'ObjectValueViewer') return -1
         return 0
       })
       return arr
+    },
+    range() {
+      return this.value.slice(0, this.currentLimit)
     }
   },
   methods: {
     toggleLoadExpand() {
       this.localExpand = !this.localExpand
     },
+    loadMore() {
+      this.currentLimit += this.itemsPerLoad
+    },
     cancel() {
       ac.abort()
     },
     async bake() {
-      this.progress = true
       ac = new AbortController()
 
+      this.progress = true
       this.$mixpanel.track('Receive')
 
       let receiverSelection = await bake(
@@ -165,8 +169,11 @@ export default {
         this.commitId,
         this.commitMsg,
         this.$refs.modal,
-        ac.signal
+        ac.signal,
+        this.nearestObjectId,
+        this.pathFromNearestObject
       )
+
       if (receiverSelection) {
         receiverSelection.fullKeyName = this.fullKeyName
 
@@ -175,6 +182,7 @@ export default {
           receiverSelection: receiverSelection
         })
       }
+
       this.progress = false
     }
   }

--- a/src/components/ObjectSimpleViewer.vue
+++ b/src/components/ObjectSimpleViewer.vue
@@ -110,7 +110,7 @@ export default {
             name,
             value: val,
             type: 'ObjectListViewer',
-            description: `List (${val.length} elements haha)`
+            description: `List (${val.length} elements)`
           })
           // TODO -> list value template displayer
         } else if (typeof val === 'object' && val !== null) {

--- a/src/components/ObjectSpeckleViewer.vue
+++ b/src/components/ObjectSpeckleViewer.vue
@@ -152,8 +152,6 @@ export default {
       let arr = []
       this.updatedObjectId = this.object.data.id ?? this.nearestObjectId
       const delimiter = ':::'
-      console.log(this.updatedObjectId, delimiter)
-      console.log(this.nearestObjectId)
       for (let [key, val] of entries) {
         let name = key
         if (key.startsWith('__')) continue
@@ -166,7 +164,6 @@ export default {
           if (val.length > 0 && val[0].referencedId) {
             let firstObj = await this.getObjectFromCurrentStreamWithId(val[0].referencedId)
             speckleTypeOfFirstObj = firstObj?.data?.stream?.object?.data?.speckle_type
-            console.log('value asdfasdf', speckleTypeOfFirstObj)
           }
 
           if (speckleTypeOfFirstObj === 'Speckle.Core.Models.DataChunk') {
@@ -257,16 +254,13 @@ export default {
     },
     async getObjectFromCurrentStreamWithId(id) {
       let client = createClient()
-      let result = await client.query({
+      return await client.query({
         query: objectQuery,
         variables: {
           streamId: this.streamId,
           id: id
         }
       })
-      // .then((result) => console.log('asdfasdfsadf', result))
-      console.log('asdfasdfasdf', result)
-      return result
     }
   }
 }


### PR DESCRIPTION
Currently, when received a chunked list of data, the data seen are the chunked lists.
![image](https://github.com/specklesystems/speckle-excel/assets/43247197/412c63e7-bcef-4cbb-a21c-a540e823e7dd)

The object above is a huge table which serialized into a list of 25 data chunks. Unfortunately, receiving the data like this results in each data chunk becoming a row. The data is not being properly flattened.

Now, the data is be properly flattened as you can see in the image below (the object count is approximate to save time receiving objects that the user might not care about)
![image](https://github.com/specklesystems/speckle-excel/assets/43247197/bd4ee949-88bd-4f5f-a950-eaf36e4817fe)

And the individual rows can be received as rows.
